### PR TITLE
fix router link to 'type' page

### DIFF
--- a/src/app/pages/documentation/framework/getting-started.component.ts
+++ b/src/app/pages/documentation/framework/getting-started.component.ts
@@ -18,7 +18,7 @@ import { Component } from '@angular/core';
 
         <p>
             Deepkit Framework is based on the TypeScript runtime type system @deepkit/type. 
-            See <a routerLink="/documentation/type/getting-started">Type: Getting Started</a> for more information.
+            See <a routerLink="/documentation/type">Type: Getting Started</a> for more information.
         </p>
         
         <p>


### PR DESCRIPTION
### Summary of changes

The page https://deepkit.io/documentation/type/getting-started doesn't exists but https://deepkit.io/documentation/type does

### Relinquishment of Rights

Please mark following checbkox to confirm that you relinquish all rights of your changes, including code, text, and other copyrighted material.

- [x] I waive and relinquish all rights regarding this changes including code, text, and images to Deepkit UG (limited). This changes including code, text, and images, are under MIT license without attribution requirement.
