### PR TITLE
Replace Partial<Config, 'key'> with Pick<Config, 'key'>

### DIFF
--- a/src/app/pages/documentation/framework/configuration.component.ts
+++ b/src/app/pages/documentation/framework/configuration.component.ts
@@ -79,18 +79,18 @@ import { Component } from '@angular/core';
         <h4>Configuration partial</h4>
 
         <p>
-            To inject a partial of configuration options, use the <code>Partial</code> TypeScript type function.
+            To inject a partial configuration object, use the <code>Pick</code> TypeScript type function.
         </p>
 
         <textarea codeHighlight title="website.ts">
             import { Config } from './app-config.ts';
             
-            type WebsiteSettings = Partial<Config, 'pageTitle' | 'domain'>
+            type WebsiteSettings = Pick<Config, 'pageTitle' | 'domain'>
             
             class MyWebsite {
                 constructor(protected settings: WebsiteSettings) {}
                 //or
-                // constructor(protected settings: Partial<Config, 'pageTitle' | 'domain'>) {}
+                // constructor(protected settings: Pick<Config, 'pageTitle' | 'domain'>) {}
             
                 @http.GET()
                 helloWorld() {

--- a/src/app/pages/documentation/framework/dependency-injection.component.ts
+++ b/src/app/pages/documentation/framework/dependency-injection.component.ts
@@ -224,13 +224,13 @@ import { Component } from '@angular/core';
             }
 
             class MainDatabase extends Database {
-                constructor(databaseSettings: Partial<Config, 'databaseUrl'>) {
+                constructor(databaseSettings: Pick<Config, 'databaseUrl'>) {
                     super(new MongoDatabaseAdapter(databaseSettings), []);
                 }
             }
             
             //or use multiple values and define as type alias
-            type DBConfig = Partial<Config, 'databaseUrl' | 'anotherOption'>;
+            type DBConfig = Pick<Config, 'databaseUrl' | 'anotherOption'>;
             class MainDatabase extends Database {
                 constructor(databaseSettings: DBConfig) {
             }

--- a/src/app/pages/documentation/framework/modules.component.ts
+++ b/src/app/pages/documentation/framework/modules.component.ts
@@ -278,7 +278,7 @@ import { Component } from '@angular/core';
             inject the whole configuration object, a single value, or a partial of the configuration.
         </p>
 
-        <h4>Partial</h4>
+        <h4>Pick</h4>
 
         <p>
             To inject only a sub section of configuration values use the <code>Pick</code> type function.

--- a/src/app/pages/documentation/type/types.component.ts
+++ b/src/app/pages/documentation/type/types.component.ts
@@ -10,7 +10,7 @@ import { Component } from '@angular/core';
             Deepkit Type supports almost all TypeScript types out of the box. It could be a simple string, number,
             boolean,
             or more complex classes and interfaces, as well as computed types based on type functions like
-            <code>Partial</code>,
+            <code>Pick</code>,
             and even generics.
         </p>
 


### PR DESCRIPTION
### Summary of changes

There were a couple of instances where partial configuration objects were created using `Partial` instead of `Pick`. I fixed those and replaced an example of a computed type with `Pick` because `Partial` is used only once in the docs


### Relinquishment of Rights

Please mark following checbkox to confirm that you relinquish all rights of your changes, including code, text, and other copyrighted material.

- [x] I waive and relinquish all rights regarding this changes including code, text, and images to Deepkit UG (limited). This changes including code, text, and images, are under MIT license without attribution requirement.
